### PR TITLE
Reduce amount of data downloaded in-advance

### DIFF
--- a/src/ngsw-config.json
+++ b/src/ngsw-config.json
@@ -33,11 +33,7 @@
       "installMode": "prefetch",
       "updateMode": "prefetch",
       "resources": {
-        "files": [
-          "/assets/**",
-          "/svg/md*",
-          "/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
-        ]
+        "files": []
       }
     }
   ]


### PR DESCRIPTION
I'm not 100% sure on the current configuration of the ServiceWorker for the HI-app, but I think it could currently start downloading all these assets on every (second?) visit of the app. (It will differ from browser to OS how these `prefetch`/background downloads are handled and when they are triggered.)

And in practice only a few of these assets are actually being used (the RC/WA-logo's, the fonts, only 2 icons); So actually a lot of files(all the other possible (MD-)icons etc.) will be downloaded for nothing.