### PR TITLE
Include tests on Node v18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['16']
+        node-version: ['16', '18']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
To prepare for (easy) upgrading once v18 becomes the Node.js LTS version