### PR TITLE
Let relative/internal links in HTML/Markdown-content NOT open new window/tab

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,15 +24,17 @@ export function markedOptionsFactory(): MarkedOptions {
   };
 
   renderer.link = (href: string, title: string, text: string): string => {
-    return `<a href="${href}" target="_blank" rel="noopener noreferrer" ${
-      title ? ` title="${title}"` : ''
-    }">${text}</a>`;
+    const isExternal = !href.startsWith('/');
+    return `<a href="${href}"
+     ${isExternal ? `target="_blank" rel="external noopener noreferrer"` : ''}
+     ${title ? ` title="${title}"` : ''}
+     >${text}</a>`;
   };
 
   renderer.html = (html: string): string => {
     return html.replaceAll(
-      /(?<raw_a_link>href=)/gi,
-      ` target="_blank" rel="noopener noreferer" $1`,
+      /(?<raw_a_href>href=[\s"']*(?:http|\/\/))/gi,
+      ` target="_blank" rel="external noopener noreferrer" $<raw_a_href>`,
     );
   };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,9 +20,10 @@ export const environment = {
   mainPageIntroduction:
     'Intro test-content: \n\n' +
     '<b>Image:</b> <img src="/favicon.ico" alt=""/> \n\n' +
-    ' <b>Link:</b> <a href="https://github.com/rodekruis/helpful-information" target="_blank" rel="noopener noreferrer">helpful-information on GitHub</a> \n\n ' +
+    ' <b>Link:</b> <a href="https://github.com/rodekruis/helpful-information">helpful-information on GitHub</a> \n\n ' +
+    ' <b>Internal:</b> <a href="/test">Test</a> \n\n ' +
     'Markdown content: \n\n' +
-    '_inline_ **styles** and [links](https://example.org) : \n\n' +
+    '_inline_ **styles** and [external links](https://example.org) or [internal links](/test) \n\n' +
     '### Level 3 headings down only? \n\n' +
     'Section content... \n\n' +
     '--- \n\n' +


### PR DESCRIPTION
Useful to use for #647 or in #116 